### PR TITLE
fix: Update reference key in payment verification API call

### DIFF
--- a/src/app/payment-verification/page.tsx
+++ b/src/app/payment-verification/page.tsx
@@ -21,7 +21,7 @@ const PaymentVerification = () => {
         const res = await axios.post(
           `${environment?.baseUrl}${environment?.paymentVerification}`,
           {
-            ref_id: token,
+            reference: token,
           }
         );
 


### PR DESCRIPTION
- Changed the key from 'ref_id' to 'reference' in the payment verification request to align with API specifications.